### PR TITLE
Fix isse #7: Automatic USB bus selection for EPOS/2/4 motor drivers

### DIFF
--- a/ros2_ws/src/motor_controller/src/DriverInterface.h
+++ b/ros2_ws/src/motor_controller/src/DriverInterface.h
@@ -2,6 +2,7 @@
 #define __DRIVER_INTERFACE_H__
 
 #include <cmath>
+#include <string>
 
 #include "ros2_logger.h"
 
@@ -58,7 +59,7 @@ namespace mcd {
          * @param port port descriptor
          * @return true if successful connected, false otherwise
          */
-        virtual bool connect( const char* port ) = 0;
+        virtual bool connect( const std::string& port ) = 0;
         virtual void disconnect() = 0;
         virtual bool is_connected() = 0;
 

--- a/ros2_ws/src/motor_controller/src/LayerClasses/CVmc.cpp
+++ b/ros2_ws/src/motor_controller/src/LayerClasses/CVmc.cpp
@@ -23,7 +23,7 @@ namespace VMC {
 	static constexpr int MOTOR_INDEX_LEFT  = 2;
 
 
-	bool CVmc::connect( const char* port ) { init( port ); return isConnected(); }
+	bool CVmc::connect( const std::string& port ) { init( port ); return isConnected(); }
 	void CVmc::disconnect() {
 		///////////////////////////////////// @@@
 		//  fclose(file );
@@ -478,7 +478,7 @@ char port[20];
 #endif
 	}
 
-	void CVmc::init(const char* comPort) {
+	void CVmc::init(const std::string& comPort) {
 #ifdef WIN32
 		DWORD threadId;
 #elif REAL_TIME
@@ -501,12 +501,11 @@ char port[20];
 
 		_digitalInputUpdate= false;
 
-		strcpy(_comPort, "No connection!");
-
 		_apiObject= new VMC::CvmcAPI();
-
+		
+		strcpy(_comPort, comPort.c_str());
 		_apiObject->selectHardwareAdapter(VMC::RS232);
-		_apiObject->selectDevice(comPort);
+		_apiObject->selectDevice(_comPort);
 
 		int isComPortOpened= _apiObject->openDevice();
 
@@ -525,13 +524,13 @@ char port[20];
 			LOG_LN_INFO("voltage is %f", voltage);
 			
 			if(voltage == 0) 
-				return;
+			return;
 		} else {
+			strcpy(_comPort, "No connection!");
 			return;
 		}
 
 		_isConnected= 1;
-		strncpy(_comPort, comPort, 40);
 		_comPort[40]= 0x00;
 
 		clearResponseList();
@@ -557,7 +556,7 @@ char port[20];
 		else return;
 
 		_isConnected= 1;
-		strncpy(_comPort, comPort, 40);
+		strncpy(_comPort, comPort.c_str(), 40);
 		_comPort[40]= 0x00;
 
 

--- a/ros2_ws/src/motor_controller/src/LayerClasses/CVmc.h
+++ b/ros2_ws/src/motor_controller/src/LayerClasses/CVmc.h
@@ -71,7 +71,7 @@ public:
 	// Interface implementation
 	float ticks_per_revolution() override { return -461.817; };
 
-	bool connect( const char* port ) override;
+	bool connect( const std::string& port ) override;
 	void disconnect() override;
 	bool is_connected() override;
 
@@ -346,7 +346,7 @@ private:
 
 	void enterCriticalSection();
 	void leaveCriticalSection();
-	void init(const char* comPort);
+	void init(const std::string& comPort);
 	VMC::CvmcAPI *_apiObject;
 };
 

--- a/ros2_ws/src/motor_controller/src/controller.cc
+++ b/ros2_ws/src/motor_controller/src/controller.cc
@@ -143,7 +143,7 @@ namespace controller {
 		}
 
 		LOG_LN_INFO( "Trying to connect to %s", mc_name.c_str() );
-		if( active_motor_controller->connect( rover.motor_controller_port.c_str() ) ) {
+		if( active_motor_controller->connect( rover.motor_controller_port ) ) {
 			active_motor_controller->reset_ticks();
 			
 			current_motor_ticks.cm_per_tick = 1.0 / mcd::util::tick_per_cm(

--- a/ros2_ws/src/motor_controller/src/epos/epos.cpp
+++ b/ros2_ws/src/motor_controller/src/epos/epos.cpp
@@ -54,10 +54,25 @@ void* EPOS::thread_function(void* param) {
 	return nullptr;
 }
 
-bool EPOS::connect( const char* port ) {
+bool EPOS::connect( const std::string& port ) {
 	g_pKeyHandle  = 0;
 	g_isConnected = false;
-	strncpy( g_PortName, port, sizeof(g_PortName)-1 );
+
+	if( port.empty() ) { // find connected usb bus
+		LOG_LN_INFO( "Auto-Find correct EPOS port" );
+
+		int endOfSelection = 0;
+		if(VCS_GetPortNameSelection(g_DeviceName, g_ProtocolStackName, g_InterfaceName, true, g_PortName, maxStrSize, &endOfSelection, &g_pErrorCode) == 0) {
+			LOG_LN_WARN( COL(FG_BRIGHT_YELLOW, "Cannot Get Port Name Selection for EPOS Device! (0x%x)"), g_pErrorCode );
+			return false;
+		}
+
+		LOG_LN_INFO( "Available EPOS port: " COL(FG_BRIGHT_BLUE, "%s"), g_PortName );
+	} else {
+		LOG_LN_INFO( "Connect via given port: " COL(FG_BRIGHT_BLUE, "%s"), port.c_str() );
+		strncpy( g_PortName, port.c_str(), sizeof(g_PortName)-1 );
+	}
+
 
 	LOG_LN_DEBUG( "[" COL(FG_BRIGHT_BLUE, "%s") "] trying to connect via port " COL(FG_BRIGHT_BLUE, "%s"), g_DeviceName, g_PortName );
 

--- a/ros2_ws/src/motor_controller/src/epos/epos.h
+++ b/ros2_ws/src/motor_controller/src/epos/epos.h
@@ -19,7 +19,7 @@ namespace EPOS {
 		public:
 		float ticks_per_revolution() override { return 148000; } // 148000 tics per rev, 26 cm diameter, 81.68 cm per rev, 1811.9178 tics/cm
 	
-		bool connect( const char* port ) override;
+		bool connect( const std::string& port ) override;
 		void disconnect() override;
 		bool is_connected() override;
 	
@@ -36,6 +36,7 @@ namespace EPOS {
 		~EPOS() override;
 	
 	private:
+		static constexpr unsigned maxStrSize = 100;
 		//EPOS2 Functions
 		bool openEPOSDevice();
 		bool closeEPOSDevice();
@@ -44,14 +45,14 @@ namespace EPOS {
 	
 		//EPOS2 Variables
 		EPOS_VERSION controller_version;
-		char g_DeviceName[100] = "EPOS";
-		char g_ProtocolStackName[100] = "MAXON SERIAL V2";
-		char g_InterfaceName[100] = "USB";
+		char g_DeviceName[maxStrSize] = "EPOS";
+		char g_ProtocolStackName[maxStrSize] = "MAXON SERIAL V2";
+		char g_InterfaceName[maxStrSize] = "USB";
 		int  g_baudrate = 1000000;
 		
 		unsigned int g_pErrorCode;
 		void* g_pKeyHandle;
-		char  g_PortName[100] = "";
+		char  g_PortName[maxStrSize] = "";
 		bool  g_isConnected = false;
 		
 		int g_maxRPM = 4000;

--- a/ros2_ws/src/volksbot/config/rovers.yaml
+++ b/ros2_ws/src/volksbot/config/rovers.yaml
@@ -23,7 +23,7 @@ always_publish: true
 # wheel_diameter         # in cm
 # wheel_base             # in cm - distance between wheel center points
 # motor_controller       # id of motor controller
-# motor_controller_port  # port to be passed to the specified motor controller 
+# motor_controller_port  # [optional] port to be passed to the specified motor controller 
 # udev_symlink           # device port mapping (usually: /dev/xyz) as noted in 42-usb-serial-volksbot.rules
 # ip_lms                 # static ip of laserscanner
 # wheel_mapping          # 2x2 matrix mapping wheels to motors [ m0_w0, m0_w1, 
@@ -35,7 +35,7 @@ name:                   VOX1
 wheel_diameter:         26.0
 wheel_base:             50.0
 motor_controller:       EPOS4
-motor_controller_port:  USB0
+# motor_controller_port:  USB0
 udev_symlink:           /dev/EPOS4
 ip_lms:                 192.168.0.14
 wheel_mapping:          [  0, -1, 
@@ -47,7 +47,7 @@ name:                   VOX2
 wheel_diameter:         26.0
 wheel_base:             50.0
 motor_controller:       EPOS4
-motor_controller_port:  USB0
+# motor_controller_port:  USB0
 udev_symlink:           /dev/EPOS4
 ip_lms:                 192.168.0.12
 wheel_mapping:          [  0, -1, 

--- a/ros2_ws/src/volksbot/src/volksbot.cc
+++ b/ros2_ws/src/volksbot/src/volksbot.cc
@@ -128,7 +128,6 @@ static bool parse_rover( const YAML::Node& rover_map, Rover& out_rover ) {
         !rover_map["wheel_diameter"]         ||
         !rover_map["wheel_base"]             ||
         !rover_map["motor_controller"]       ||
-        !rover_map["motor_controller_port"]  ||
         !rover_map["udev_symlink"]           ||
         !rover_map["ip_lms"]                 
     ) {
@@ -143,9 +142,12 @@ static bool parse_rover( const YAML::Node& rover_map, Rover& out_rover ) {
     wheel_diameter        = rover_map["wheel_diameter"]       .as<float>();
     wheel_base            = rover_map["wheel_base"]           .as<float>();
     motor_controller      = rover_map["motor_controller"]     .as<std::string>();
-    motor_controller_port = rover_map["motor_controller_port"].as<std::string>();
     udev_symlink          = rover_map["udev_symlink"]         .as<std::string>();
     ip_lms                = rover_map["ip_lms"]               .as<std::string>();
+
+    motor_controller_port = "";
+    if ( rover_map["motor_controller_port"] )
+        motor_controller_port = rover_map["motor_controller_port"].as<std::string>();
 
     float wheel_map[4] = { 1.0f, 0.0f, 0.0f, 1.0f }; // default: direct mapping
     if( rover_map["wheel_mapping"] ) {


### PR DESCRIPTION
EPOS motor driver now automatically selects the USB port it self is connected to, fixing the spurious bug: 
```bash
Cannot Open EPOS Device! (0x10000008)
```